### PR TITLE
replace deprecated method in iOS 14

### DIFF
--- a/AttachmentInput/AttachmentInput/View/AttachmentInputView.swift
+++ b/AttachmentInput/AttachmentInput/View/AttachmentInputView.swift
@@ -84,7 +84,7 @@ class AttachmentInputView: UIView {
         ret.append(SectionType.CameraSection(items: [SectionItemType.CameraItem]))
         let controllerObservable = Observable.just(ret)
 
-        self.checkPhotoAuthorizationStatus { [weak self] authorized in
+        self.requestAuthorizationIfNeeded { [weak self] authorized in
             if authorized {
                 self?.fetchAssets()
             }
@@ -113,7 +113,7 @@ class AttachmentInputView: UIView {
         }).disposed(by: self.disposeBag)
     }
 
-    private func checkPhotoAuthorizationStatus(completion: @escaping (_ authorized: Bool) -> Void) {
+    private func requestAuthorizationIfNeeded(completion: @escaping (_ authorized: Bool) -> Void) {
         let status: PHAuthorizationStatus
         if #available(iOS 14, *) {
             status = PHPhotoLibrary.authorizationStatus(for: .readWrite)

--- a/AttachmentInput/AttachmentInput/View/AttachmentInputView.swift
+++ b/AttachmentInput/AttachmentInput/View/AttachmentInputView.swift
@@ -128,7 +128,7 @@ class AttachmentInputView: UIView {
         case .notDetermined:
             if #available(iOS 14, *) {
                 PHPhotoLibrary.requestAuthorization(for: .readWrite, handler: { status in
-                    completion(status == .authorized)
+                    completion(status == .authorized || status == .limited)
                 })
             } else {
                 PHPhotoLibrary.requestAuthorization({ (status) in

--- a/AttachmentInput/AttachmentInput/View/AttachmentInputView.swift
+++ b/AttachmentInput/AttachmentInput/View/AttachmentInputView.swift
@@ -114,16 +114,27 @@ class AttachmentInputView: UIView {
     }
 
     private func checkPhotoAuthorizationStatus(completion: @escaping (_ authorized: Bool) -> Void) {
-        let status = PHPhotoLibrary.authorizationStatus()
+        let status: PHAuthorizationStatus
+        if #available(iOS 14, *) {
+            status = PHPhotoLibrary.authorizationStatus(for: .readWrite)
+        } else {
+            status = PHPhotoLibrary.authorizationStatus()
+        }
         switch (status) {
         case .authorized, .limited:
             completion(true)
         case .denied, .restricted:
             completion(false)
         case .notDetermined:
-            PHPhotoLibrary.requestAuthorization({ (status) in
-                completion(status == .authorized)
-            })
+            if #available(iOS 14, *) {
+                PHPhotoLibrary.requestAuthorization(for: .readWrite, handler: { status in
+                    completion(status == .authorized)
+                })
+            } else {
+                PHPhotoLibrary.requestAuthorization({ (status) in
+                    completion(status == .authorized)
+                })
+            }
         @unknown default:
             fatalError()
         }


### PR DESCRIPTION
`authorizationStatus()` and `requestAuthorization(_:)` are deprecated.
`authorizationStatus(for:)` and `requestAuthorization(for:handler:)` are available in iOS14.0 and later.

reference: https://developer.apple.com/documentation/photokit/phphotolibrary

impact: new "Select Photos..." button will be added to the authorization require alert.